### PR TITLE
Login fix - the TwitterLoginButton requires an Activity, not a Context, to make callbacks work for login

### DIFF
--- a/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitModule.java
+++ b/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitModule.java
@@ -52,10 +52,10 @@ public class FabricTwitterKitModule extends ReactContextBaseJavaModule implement
             } else if (resultCode == Activity.RESULT_CANCELED) {
                 sendCallback(false, true, false);
             }
-            if (loginButton != null) {
-                loginButton.onActivityResult(requestCode, resultCode, data);
-                loginButton = null;
-            }
+        }
+        if (loginButton != null) {
+            loginButton.onActivityResult(requestCode, resultCode, data);
+            loginButton = null;
         }
     }
 
@@ -87,7 +87,7 @@ public class FabricTwitterKitModule extends ReactContextBaseJavaModule implement
     @ReactMethod
     public void login(final Callback callback) {
 
-        loginButton = new TwitterLoginButton(reactContext);
+        loginButton = new TwitterLoginButton(getCurrentActivity());
         loginButton.setCallback(new com.twitter.sdk.android.core.Callback<TwitterSession>() {
             @Override
             public void success(Result<TwitterSession> sessionResult) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
-import { NativeModules } from 'react-native'
+import { NativeModules } from 'react-native';
 
 export default NativeModules.FabricTwitterKit;


### PR DESCRIPTION
Couple of fixes here -
1. When the TwitterLoginButton is initialised it needs to be given the current activity, not the ReactContext. This fixes a bug that occurs during login.
2. I've pulled the loginButton code in onActivityResult out of the if statement to let callbacks complete successfully - previously it would not call loginButton.onActivityResult as the request code is not 112112.

I've tested this in RN 0.29 to 0.32, all seems to work well (no testing pre-0.29 due to the Activity/Application split that happens in 0.29).
