### PR TITLE
Add fetch tweet API

### DIFF
--- a/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitModule.java
+++ b/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitModule.java
@@ -1,3 +1,8 @@
+// -------------------------------------------------------------------------------------------
+// Modifications:
+// Copyright (C) 2016 Sony Interactive Entertainment Inc.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+// --------------------------------------------------------------------------------------------
 package com.tkporter.fabrictwitterkit;
 
 import android.app.Activity;

--- a/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitUtils.java
+++ b/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitUtils.java
@@ -1,3 +1,7 @@
+// -------------------------------------------------------------------------------------------
+// Copyright (C) 2016 Sony Interactive Entertainment Inc.
+// Licensed under the MIT License. See the LICENSE file in the project root for license information.
+// --------------------------------------------------------------------------------------------
 package com.tkporter.fabrictwitterkit;
 
 import com.facebook.react.bridge.Arguments;

--- a/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitUtils.java
+++ b/Android/src/main/java/com/tkporter/fabrictwitterkit/FabricTwitterKitUtils.java
@@ -1,0 +1,66 @@
+package com.tkporter.fabrictwitterkit;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+public class FabricTwitterKitUtils {
+    public static WritableMap jsonToWritableMap(String json) throws JSONException {
+        return jsonToWritableMap(new JSONObject(json));
+    }
+
+    private static WritableMap jsonToWritableMap(final JSONObject jsonObject) throws JSONException {
+        final WritableMap writableMap = Arguments.createMap();
+        final Iterator iterator = jsonObject.keys();
+        while (iterator.hasNext()) {
+            final String key = (String) iterator.next();
+            final Object value = jsonObject.get(key);
+            if (value instanceof Float || value instanceof Double) {
+                writableMap.putDouble(key, jsonObject.getDouble(key));
+            } else if (value instanceof Number) {
+                writableMap.putInt(key, jsonObject.getInt(key));
+            } else if (value instanceof String) {
+                writableMap.putString(key, jsonObject.getString(key));
+            } else if (value instanceof JSONObject) {
+                writableMap.putMap(key, jsonToWritableMap(jsonObject.getJSONObject(key)));
+            } else if (value instanceof JSONArray) {
+                writableMap.putArray(key, jsonToWritableArray(jsonObject.getJSONArray(key)));
+            } else if (value instanceof Boolean) {
+                writableMap.putBoolean(key, jsonObject.getBoolean(key));
+            } else if (value == JSONObject.NULL) {
+                writableMap.putNull(key);
+            }
+        }
+        return writableMap;
+    }
+
+    private static WritableArray jsonToWritableArray(final JSONArray jsonArray) throws JSONException {
+        final WritableArray writableArray = Arguments.createArray();
+        for (int i = 0; i < jsonArray.length(); i++) {
+
+            final Object value = jsonArray.get(i);
+            if (value instanceof Float || value instanceof Double) {
+                writableArray.pushDouble(jsonArray.getDouble(i));
+            } else if (value instanceof Number) {
+                writableArray.pushInt(jsonArray.getInt(i));
+            } else if (value instanceof String) {
+                writableArray.pushString(jsonArray.getString(i));
+            } else if (value instanceof Boolean) {
+                writableArray.pushBoolean(jsonArray.getBoolean(i));
+            } else if (value instanceof JSONObject) {
+                writableArray.pushMap(jsonToWritableMap(jsonArray.getJSONObject(i)));
+            } else if (value instanceof JSONArray) {
+                writableArray.pushArray(jsonToWritableArray(jsonArray.getJSONArray(i)));
+            } else if (value == JSONObject.NULL) {
+                writableArray.pushNull();
+            }
+        }
+        return writableArray;
+    }
+}

--- a/FabricTwitterKit/FabricTwitterKit.m
+++ b/FabricTwitterKit/FabricTwitterKit.m
@@ -38,20 +38,76 @@ RCT_EXPORT_METHOD(fetchProfile:(RCTResponseSenderBlock)callback)
 {
     TWTRAPIClient *client = [[TWTRAPIClient alloc] init];
     TWTRSessionStore *store = [[Twitter sharedInstance] sessionStore];
-    
+
     TWTRSession *lastSession = store.session;
-    
+
     if(lastSession) {
         NSString *showEndpoint = @"https://api.twitter.com/1.1/users/show.json";
         NSDictionary *params = @{@"user_id": lastSession.userID};
-        
+
         NSError *clientError;
         NSURLRequest *request = [client
                                  URLRequestWithMethod:@"GET"
                                  URL:showEndpoint
                                  parameters:params
                                  error:&clientError];
-        
+
+          if (request) {
+            [client
+             sendTwitterRequest:request
+             completion:^(NSURLResponse *response,
+                          NSData *data,
+                          NSError *connectionError) {
+                 if (data) {
+                     // handle the response data e.g.
+                     NSError *jsonError;
+                     NSDictionary *json = [NSJSONSerialization
+                                           JSONObjectWithData:data
+                                           options:0
+                                           error:&jsonError];
+                     NSLog(@"%@",[json description]);
+                     callback(@[[NSNull null], json]);
+                 }
+                 else {
+                     NSLog(@"Error code: %ld | Error description: %@", (long)[connectionError code], [connectionError localizedDescription]);
+                     callback(@[[connectionError localizedDescription]]);
+                 }
+             }];
+        }
+        else {
+            NSLog(@"Error: %@", clientError);
+        }
+
+    }
+
+
+}
+
+RCT_EXPORT_METHOD(fetchTweet:(NSDictionary *)options :(RCTResponseSenderBlock)callback)
+{
+    TWTRAPIClient *client = [[TWTRAPIClient alloc] init];
+    TWTRSessionStore *store = [[Twitter sharedInstance] sessionStore];
+    NSString *id = options[@"id"];
+    NSString *trim_user = options[@"trim_user"];
+    NSString *include_my_retweet = options[@"include_my_retweet"];
+
+    TWTRSession *lastSession = store.session;
+
+    if(lastSession) {
+        NSString *showEndpoint = @"https://api.twitter.com/1.1/statuses/show.json";
+        NSDictionary *params = @{
+                                    @"id": id,
+                                    @"trim_user": trim_user,
+                                    @"include_my_retweet": include_my_retweet
+                                };
+
+        NSError *clientError;
+        NSURLRequest *request = [client
+                                 URLRequestWithMethod:@"GET"
+                                 URL:showEndpoint
+                                 parameters:params
+                                 error:&clientError];
+
         if (request) {
             [client
              sendTwitterRequest:request
@@ -77,36 +133,35 @@ RCT_EXPORT_METHOD(fetchProfile:(RCTResponseSenderBlock)callback)
         else {
             NSLog(@"Error: %@", clientError);
         }
-        
+
     }
-    
-    
+
 }
 
 RCT_EXPORT_METHOD(composeTweet:(NSDictionary *)options :(RCTResponseSenderBlock)callback) {
-    
+
     NSString *body = options[@"body"];
-    
+
     TWTRComposer *composer = [[TWTRComposer alloc] init];
-    
+
     if (body) {
         [composer setText:body];
     }
-    
+
     UIViewController *rootView = [UIApplication sharedApplication].keyWindow.rootViewController;
     [composer showFromViewController:rootView completion:^(TWTRComposerResult result) {
-        
+
         bool completed = NO, cancelled = NO, error = NO;
-        
+
         if (result == TWTRComposerResultCancelled) {
             cancelled = YES;
         }
         else {
             completed = YES;
         }
-        
+
         callback(@[@(completed), @(cancelled), @(error)]);
-        
+
     }];
 }
 
@@ -114,7 +169,7 @@ RCT_EXPORT_METHOD(logOut)
 {
     TWTRSessionStore *store = [[Twitter sharedInstance] sessionStore];
     NSString *userID = store.session.userID;
-    
+
     [store logOutUserID:userID];
 }
 

--- a/FabricTwitterKit/FabricTwitterKit.m
+++ b/FabricTwitterKit/FabricTwitterKit.m
@@ -5,6 +5,9 @@
 //  Created by Trevor Porter on 8/1/16.
 //  Copyright © 2016 Trevor Porter. All rights reserved.
 //
+//  Modifications:
+//  Copyright (C) 2016 Sony Interactive Entertainment Inc.
+//  Licensed under the MIT License. See the LICENSE file in the project root for license information.
 
 #import "FabricTwitterKit.h"
 #import "RCTBridgeModule.h"

--- a/Twitter.js
+++ b/Twitter.js
@@ -13,6 +13,9 @@ module.exports = {
   fetchProfile: function (cb) {
     SMXTwitter.fetchProfile(cb);
   },
+  fetchTweet: function (options, cb) {
+    SMXTwitter.fetchTweet(options, cb);
+  },
   logOut: function () {
     SMXTwitter.logOut();
   },

--- a/Twitter.js
+++ b/Twitter.js
@@ -1,5 +1,9 @@
 /**
  * @providesModule Twitter
+ *
+ * Modifications:
+ * Copyright (C) 2016 Sony Interactive Entertainment Inc.
+ * Licensed under the MIT License. See the LICENSE file in the project root for license information.
  */
 'use strict';
 


### PR DESCRIPTION
## Summary
-  Added to API to fetch single tweet
-  Fix for https://github.com/tkporter/react-native-fabric-twitterkit/issues/4

## Changes
-  Added `jsonToWritableMap`
-  Modified `fetchProfile ()` to use `jsonToWritableMap `
-  Added `fetchTweet()` API
