### PR TITLE
Correct imports for RN >= 0.40

### DIFF
--- a/FabricTwitterKit/FabricTwitterKit.m
+++ b/FabricTwitterKit/FabricTwitterKit.m
@@ -10,9 +10,9 @@
 //  Licensed under the MIT License. See the LICENSE file in the project root for license information.
 
 #import "FabricTwitterKit.h"
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
-#import "RCTBridge.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTBridge.h>
 //#import <Crashlytics/Crashlytics.h>
 #import <TwitterKit/TwitterKit.h>
 


### PR DESCRIPTION
Fix for build errors in iOS due to React Native 0.40's breaking change: https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d

I believe this will break older versions of RN.