### PR TITLE
Change iOS imports to support react-native >= 0.40

### DIFF
--- a/FabricTwitterKit/FabricTwitterKit.h
+++ b/FabricTwitterKit/FabricTwitterKit.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Trevor Porter. All rights reserved.
 //
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface FabricTwitterKit : NSObject <RCTBridgeModule> {
     RCTResponseSenderBlock _callback;

--- a/FabricTwitterKit/FabricTwitterKit.m
+++ b/FabricTwitterKit/FabricTwitterKit.m
@@ -10,9 +10,9 @@
 //  Licensed under the MIT License. See the LICENSE file in the project root for license information.
 
 #import "FabricTwitterKit.h"
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
-#import "RCTBridge.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTBridge.h>
 //#import <Crashlytics/Crashlytics.h>
 #import <TwitterKit/TwitterKit.h>
 


### PR DESCRIPTION
Fixes #22 

Requires major version rev because it will break any users who are on react-native < 0.40.

Could probably add something to the Readme to indicate users on an earlier RN version should use the older version of this library.